### PR TITLE
Separate the supervisord config file for the wine process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture i386 && \
     mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86_64.msi && \
     apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD supervisord-wine.conf /etc/supervisor/conf.d/supervisord-wine.conf
 
 ENV WINEPREFIX /root/prefix32
 ENV WINEARCH win32

--- a/supervisord-wine.conf
+++ b/supervisord-wine.conf
@@ -1,0 +1,6 @@
+[program:explorer]
+command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/i386-windows/explorer.exe
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -22,13 +22,6 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-[program:explorer]
-command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/i386-windows/explorer.exe
-autorestart=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-
 [program:fluxbox]
 command=/usr/bin/fluxbox
 autorestart=true


### PR DESCRIPTION
Separate the `supervisord` config for the `wine` process, so we can easily override it